### PR TITLE
修复动作生成链的运行依赖缺失

### DIFF
--- a/scripts/installing/gen_motion/install.sh
+++ b/scripts/installing/gen_motion/install.sh
@@ -160,7 +160,8 @@ ensure_env aaagf-retarget-bpy 3.11
 "${CONDA_BIN}" install -n aaagf-momask -y --override-channels \
   -c conda-forge "python=3.10" pip ffmpeg "numpy=1.23.5"
 "${CONDA_BIN}" install -n aaagf-retarget-bpy -y --override-channels \
-  -c conda-forge "python=3.11" pip xorg-libsm xorg-libxext xorg-libxrender xorg-libxi libxkbcommon.so.0
+  -c conda-forge "python=3.11" pip xorg-libsm xorg-libxext xorg-libxrender \
+  xorg-libxi libxkbcommon.so.0 # Linux runtime libraries required by bpy for motion retargeting and FBX export
 
 "${CONDA_BIN}" run -n aaagf-puppeteer python -m pip install \
   torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 \

--- a/scripts/installing/gen_motion/install.sh
+++ b/scripts/installing/gen_motion/install.sh
@@ -160,7 +160,7 @@ ensure_env aaagf-retarget-bpy 3.11
 "${CONDA_BIN}" install -n aaagf-momask -y --override-channels \
   -c conda-forge "python=3.10" pip ffmpeg "numpy=1.23.5"
 "${CONDA_BIN}" install -n aaagf-retarget-bpy -y --override-channels \
-  -c conda-forge "python=3.11" pip xorg-libsm xorg-libxext xorg-libxrender
+  -c conda-forge "python=3.11" pip xorg-libsm xorg-libxext xorg-libxrender xorg-libxi
 
 "${CONDA_BIN}" run -n aaagf-puppeteer python -m pip install \
   torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 \

--- a/scripts/installing/gen_motion/install.sh
+++ b/scripts/installing/gen_motion/install.sh
@@ -160,7 +160,7 @@ ensure_env aaagf-retarget-bpy 3.11
 "${CONDA_BIN}" install -n aaagf-momask -y --override-channels \
   -c conda-forge "python=3.10" pip ffmpeg "numpy=1.23.5"
 "${CONDA_BIN}" install -n aaagf-retarget-bpy -y --override-channels \
-  -c conda-forge "python=3.11" pip xorg-libsm xorg-libxext xorg-libxrender xorg-libxi
+  -c conda-forge "python=3.11" pip xorg-libsm xorg-libxext xorg-libxrender xorg-libxi libxkbcommon.so.0
 
 "${CONDA_BIN}" run -n aaagf-puppeteer python -m pip install \
   torch==2.1.1 torchvision==0.16.1 torchaudio==2.1.1 \


### PR DESCRIPTION
修复动作生成链的运行依赖缺失：`aaagf-retarget-bpy` 环境需要补装两个库 `xorg-libxi libxkbcommon`