### PR TITLE
fix(harness): align image-chain stubs with the infer() contract

### DIFF
--- a/test/harness/stubs.py
+++ b/test/harness/stubs.py
@@ -579,12 +579,17 @@ class StubQwenEditModel(_StubBase):
     def load(self) -> None:
         self.calls.append({"op": "load"})
 
-    def edit(self, image: Image.Image, prompt: str, seed: int = 42,
-             steps: int = 40) -> Image.Image:
-        self.calls.append({"op": "edit", "seed": seed, "steps": steps,
+    def infer(self, image: Image.Image, prompt: str, seed: int = 42,
+              steps: int = 40) -> Image.Image:
+        self.calls.append({"op": "infer", "seed": seed, "steps": steps,
                            "prompt_len": len(prompt)})
         # Return a white-bg image with a blob, i.e. what the real T-pose edit yields.
         return make_ref_image(size=max(image.size), seed=seed)
+
+    def edit(self, image: Image.Image, prompt: str, seed: int = 42,
+             steps: int = 40) -> Image.Image:
+        """Compatibility alias, mirroring `QwenEditModel.edit`."""
+        return self.infer(image, prompt=prompt, seed=seed, steps=steps)
 
 
 class StubVideoModel(_StubBase):
@@ -690,33 +695,33 @@ class StubSeedAudioModel(_StubBase):
 class StubRMBGModel(_StubBase):
     """Mimics `models.tools.image_matting.rmbg_model.RMBGModel` — HxW float32 in [0, 1]."""
 
-    def predict(self, image: Image.Image, **kw) -> np.ndarray:
-        self.calls.append({"op": "predict", "size": image.size})
+    def infer(self, image: Image.Image, **kw) -> np.ndarray:
+        self.calls.append({"op": "infer", "size": image.size})
         arr = np.asarray(image.convert("RGB"))
         # Foreground = anything not near-white, matching RMBG's practical behaviour.
         fg = (arr < 240).any(axis=-1)
         return fg.astype(np.float32)
 
     def __call__(self, image: Image.Image, **kw) -> np.ndarray:
-        return self.predict(image, **kw)
+        return self.infer(image, **kw)
 
     def remove_background(self, image: Image.Image) -> Image.Image:
         rgba = np.array(image.convert("RGBA"))
-        rgba[..., 3] = (self.predict(image) * 255).astype(np.uint8)
+        rgba[..., 3] = (self.infer(image) * 255).astype(np.uint8)
         return Image.fromarray(rgba, "RGBA")
 
 
 class StubDepthAnythingModel(_StubBase):
     """Mimics `models.tools.image_matting.depth_anything_model.DepthAnythingModel`."""
 
-    def predict(self, image: Image.Image, **kw) -> np.ndarray:
-        self.calls.append({"op": "predict", "size": image.size})
+    def infer(self, image: Image.Image, **kw) -> np.ndarray:
+        self.calls.append({"op": "infer", "size": image.size})
         arr = np.asarray(image.convert("RGB")).astype(np.float32)
         # Darker (non-white) pixels read as "closer".
         return 1.0 - arr.mean(axis=-1) / 255.0
 
     def __call__(self, image: Image.Image, **kw) -> np.ndarray:
-        return self.predict(image, **kw)
+        return self.infer(image, **kw)
 
 
 class StubWorldMirrorModel(_StubBase):


### PR DESCRIPTION
Cross-check of the **image api** slot (8.12 wrap-up list). The chain runs, but
`test/harness/smoke.py` was red on `tpose` when checked out clean, so this PR
fixes the harness and records what was verified.

## What was broken

Two stubs in `test/harness/stubs.py` had drifted from the real interfaces, in
opposite directions:

| Stub | Exposed | Real class exposes |
|---|---|---|
| `StubQwenEditModel` | `edit()` only | `QwenEditModel.infer()` (canonical) + `edit()` (alias) |
| `StubRMBGModel` | `predict()` | `RMBGModel.infer()` — no `predict()` |
| `StubDepthAnythingModel` | `predict()` | `DepthAnythingModel.infer()` — no `predict()` |

`operators/gen_tpose_image/funcs/gen_tpose_image.py` calls `gen_model.infer()`
and `mask_model.infer()`, so the chain died on `AttributeError` before reaching
the matting stage. The rename in ae2ad21 updated the models and the operator but
not the harness.

`BaseToolModel` declares `infer()` as the abstract method and neither matting
wrapper has a `predict()`, so no `predict()` alias is kept here — a caller that
regresses to the old name should fail in the harness, not only in production.

## Verification

| Layer | Command | Result |
|---|---|---|
| CPU stub chain | `python test/harness/smoke.py` | was 5/6, now **6/6 pass** |
| Real end-to-end | `pipeline/assets_gen/gen_tpose_image/run.py --game gameA_cyberpunk_shooter --run-id auto` | **pass**, 48.34s (40 steps / 41s) |
| Integration test | `python test/test_gen_tpose_image.py` | **`Ran 2 tests in 126.346s / OK`** |

Real run on one A100-80GB, Qwen-Image-Edit-2511 + RMBG-1.4, `luffy_tpose_001`.
Output is a 1024x1024 RGBA T-pose, fully transparent background, alpha coverage
0.186, tight-cropped and centred, directly consumable by TRELLIS.2. The
`latest` symlink and `meta.json` (`git_sha`, `seed`, `steps`, model class names)
are all written as specified.

## Status of the image api slot: waiting on Seedream

Only the local half of this slot exists and could be cross-checked. There is no
cloud-API image wrapper and no API test, unlike every other capability:

| Capability | Cloud API wrapper | API test |
|---|---|---|
| `gen_3d_object` | Tripo, Meshy | `test/test_api_3d_object.py` |
| `gen_cg_video` | Seedance | `test/test_api_cg_video.py` |
| `gen_audio` | Seed-Audio, Qwen3-TTS | `test/test_api_audio.py` |
| `gen_image` | **none** | **none** |

So "image api" is verified for the local Qwen-Image-Edit path only. The API half
is blocked on the Seedream wrapper landing in `models/gen_image/`. Once it does,
I will add `test/test_api_image.py` modelled on `test/test_api_cg_video.py`, add
the corresponding stub + `--backend` entry, and re-run this cross-check. Nothing
else is blocking it.

## Found but not fixed here

Out of scope for a harness fix, listed so they are not lost in the wrap-up:

1. Repo-root `outputs/` is not gitignored. `.gitignore` covers
   `test_data/outputs/**`, but `test/test_gen_tpose_image.py` writes to
   `outputs/test_tpose/`, so running the documented integration test leaves
   untracked PNGs in the working tree. It also contradicts the "single fixed
   output root" rule in the README.
2. `README.md` documents `pipeline/mechanic/` and `pipeline/ui/`; the real paths
   are `pipeline/code_gen/gen_mechanic/` and `pipeline/code_gen/gen_ui/`.
3. `README.md` documents `operators/gen_mechanic/`, which does not exist, and
   `stubs.py` `OPERATOR_LOCATION` still maps `"mechanic"` to it.
4. `SDXLTurboModel` is orphaned: absent from the `models/README.md` wrapper
   table, not exported from `models/gen_image/__init__.py`, imported nowhere,
   and its entry point is `generate()` rather than `infer()`. Either wire it up
   or drop it.
5. The docstring in `test/test_gen_tpose_image.py` still says
   `python test/test_tpose_gen.py`, which is the pre-rename filename.
