### PR TITLE
add godot ui contamination scan and fix browser serving godot backend

### DIFF
--- a/engine_adapters/browser_serving/backends/godot_example.py
+++ b/engine_adapters/browser_serving/backends/godot_example.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import socket
 import subprocess
 import urllib.error
@@ -26,6 +27,9 @@ from ..contracts import (
     WorldRecord,
     serving_result,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def _is_tcp_port_free(host: str, port: int) -> bool:
@@ -188,7 +192,8 @@ class GodotBrowserSession:
     error: str = ""
     last_command: str = ""
     recovered_external: bool = False
-    # Godot Web export — game runs in browser via iframe.
+    # Godot Web export is a browser-native player: the game is served over
+    # HTTP and runs inside an iframe wrapper page.
     runtime_kind: str = "godot_web"
     input_transport: str = "browser_canvas"
     streaming_transport: str = "godot_web_http"
@@ -983,13 +988,9 @@ class GodotExampleBackend:
                 if session is not None
                 else ""
             )
-            reachable = bool(
-                url
-                and (
-                    self.config.dry_run
-                    or True  # desktop game is always "reachable" if running
-                )
-            )
+            # Web export has no stream server to probe; any active session
+            # URL is treated as reachable.
+            reachable = bool(url)
             return serving_result(
                 "debug.pixel_status",
                 engine="godot",
@@ -1160,18 +1161,20 @@ class GodotExampleBackend:
                     "dry_run": True,
                 },
             }
-        # Build Web export when missing or older than the Godot project. This
-        # is important for generated demos: assets/scripts may be regenerated
-        # after the previous web.pck was written.
+        # Rebuild the Web export whenever it is missing or older than the
+        # project. Generated games can regenerate scenes, scripts, and assets
+        # after a previous export, so a stale build would hide those changes
+        # from the browser session.
         web_build_dir = self._web_build_dir(session)
-        # Godot names the HTML after the preset: web.html or index.html
+        # Godot names the exported HTML after the preset ("web.html");
+        # older exports fall back to "index.html".
         web_html = web_build_dir / "web.html"
         if not web_html.is_file():
             web_html = web_build_dir / "index.html"
         if self._web_build_is_stale(web_build_dir, web_html):
-            # Godot's export command requires a file destination. Passing the
-            # build directory itself makes Godot emit `builds.html` beside the
-            # directory, so the browser backend can never find its entrypoint.
+            # Godot's export command requires a file destination: passing
+            # the build directory would emit the export beside it, where the
+            # entry-point lookup below would not find it.
             export_output = web_build_dir / "web.html"
             build_result = session.client.build.project(
                 preset="Web",
@@ -1199,13 +1202,11 @@ class GodotExampleBackend:
         session.stream_url = (
             f"http://{self.config.pixel_host}:{session.http_port}/{wrapper.name}"
         )
-        # Start HTTP server to serve the web build
         session.http_process = self._start_http_server(
             web_build_dir,
             session.http_port,
         )
         session.http_pid = int(session.http_process.pid) if session.http_process else 0
-        # Wait for HTTP to be reachable
         self._wait_for_http(session.stream_url)
         if self.config.godot_auto_open_browser:
             self._open_browser(session.stream_url)
@@ -1228,7 +1229,8 @@ class GodotExampleBackend:
         session: GodotBrowserSession,
         scene_path: str,
     ) -> dict[str, Any]:
-        # Web export doesn't need relaunch — just reload the page
+        # A Web-export session has no separate OS process to relaunch; the
+        # browser reloads the page for a new scene.
         session.updated_at = time()
         return {
             "ok": True,
@@ -1258,9 +1260,9 @@ class GodotExampleBackend:
         return Path(self.config.godot_project) / "builds"
 
     def _web_build_is_stale(self, web_build_dir: Path, web_html: Path) -> bool:
-        # Older Godot exports use `index.html` and may use custom companion
-        # filenames.  The directory is already an explicit browser build in
-        # that case, so do not force a rebuild based on the `web.*` convention.
+        # Older Godot exports use "index.html" with custom companion
+        # filenames. Treat those directories as explicit browser builds and
+        # do not force a rebuild based on the "web.*" naming convention.
         if web_html.name == "index.html" and web_html.is_file():
             return False
         required = [
@@ -1275,9 +1277,9 @@ class GodotExampleBackend:
         if self.config.godot_project is None:
             return False
         project_root = Path(self.config.godot_project)
-        # Ignore generated Godot caches and the export directory itself. All
-        # authored scenes, scripts, settings, and imported Meshy source files
-        # participate in freshness checks.
+        # Ignore generated Godot caches and the export directory itself;
+        # every authored scene, script, setting, and imported source asset
+        # participates in the freshness check.
         for path in project_root.rglob("*"):
             if not path.is_file():
                 continue
@@ -1439,13 +1441,13 @@ class GodotExampleBackend:
     <a class="button" href={game_url} target="_blank" rel="noreferrer">Open direct</a>
   </div>
   <div class="hint">
-    Click <strong>Fullscreen</strong> for a UE-style large view, or open the raw Web export directly.
+    Click <strong>Fullscreen</strong> for a larger view, or open the raw Web export directly.
   </div>
   <script>
-    // Forward Godot browser-play input through this wrapper iframe. The outer
-    // serving page and the raw Web export use different ports, so the wrapper
-    // is the bridge between them. Queue the latest message until the game has
-    // finished loading; otherwise the first keyboard packet can be lost.
+    // The admin page and the raw Web export live on different ports, so
+    // browser-play input is forwarded through this wrapper iframe. Keep the
+    // latest message queued until the game finishes loading; input sent
+    // earlier would be dropped by the not-yet-ready player.
     const gameFrame = document.getElementById("gameFrame");
     let pendingGameMessage = null;
     function forwardGameMessage(data) {{
@@ -1471,7 +1473,7 @@ class GodotExampleBackend:
         try {{
           await document.body.requestFullscreen();
         }} catch {{
-          // ignore; user can still play in the browser window.
+          // Ignored: the user can still play in the browser window.
         }}
       }}
     }});

--- a/engine_adapters/browser_serving/backends/godot_example.py
+++ b/engine_adapters/browser_serving/backends/godot_example.py
@@ -1169,9 +1169,13 @@ class GodotExampleBackend:
         if not web_html.is_file():
             web_html = web_build_dir / "index.html"
         if self._web_build_is_stale(web_build_dir, web_html):
+            # Godot's export command requires a file destination. Passing the
+            # build directory itself makes Godot emit `builds.html` beside the
+            # directory, so the browser backend can never find its entrypoint.
+            export_output = web_build_dir / "web.html"
             build_result = session.client.build.project(
                 preset="Web",
-                output_path=str(web_build_dir),
+                output_path=str(export_output),
                 debug=True,
             )
             if not build_result.get("ok"):
@@ -1254,6 +1258,11 @@ class GodotExampleBackend:
         return Path(self.config.godot_project) / "builds"
 
     def _web_build_is_stale(self, web_build_dir: Path, web_html: Path) -> bool:
+        # Older Godot exports use `index.html` and may use custom companion
+        # filenames.  The directory is already an explicit browser build in
+        # that case, so do not force a rebuild based on the `web.*` convention.
+        if web_html.name == "index.html" and web_html.is_file():
+            return False
         required = [
             web_html,
             web_build_dir / "web.pck",

--- a/pipeline/code_gen/gen_mechanic/artifacts.py
+++ b/pipeline/code_gen/gen_mechanic/artifacts.py
@@ -85,6 +85,33 @@ _GODOT_UI_PATH_PARTS = {
     "widgets",
     "overlay",
 }
+_UNITY_ENGINE_IDS = {
+    "unity",
+    "unity3d",
+    "unity_engine",
+}
+_UNITY_SOURCE_SUFFIXES = {
+    ".cs",
+}
+_UNITY_UI_PATTERNS = (
+    ("Canvas", re.compile(r"\bCanvas\b")),
+    ("UnityEngine.UI", re.compile(r"using\s+UnityEngine\.UI\b")),
+    ("Button", re.compile(r"\bButton\b")),
+    ("Text", re.compile(r"\bText\b")),
+    ("Image", re.compile(r"\bImage\b")),
+    ("RectTransform", re.compile(r"\bRectTransform\b")),
+    ("ScrollRect", re.compile(r"\bScrollRect\b")),
+    ("Toggle", re.compile(r"\bToggle\b")),
+    ("Slider", re.compile(r"\bSlider\b")),
+    ("TMP_Text", re.compile(r"\bTMP_Text\b")),
+)
+_UNITY_UI_PATH_PARTS = {
+    "ui",
+    "hud",
+    "widget",
+    "widgets",
+    "overlay",
+}
 
 
 def _has_files(path: Path) -> bool:
@@ -92,6 +119,53 @@ def _has_files(path: Path) -> bool:
         item.is_file()
         for item in path.rglob("*")
     )
+
+
+def scan_unity_ui_contamination(
+    workspace: Path,
+    current_task_files: Mapping[str, Mapping[str, Any]],
+) -> tuple[bool, list[str]]:
+    """Reject native UI implementation accidentally put in a Unity Mechanic."""
+    violations: list[str] = []
+    for relative_path in current_task_files:
+        normalized = PurePosixPath(str(relative_path).replace("\\", "/"))
+        path = workspace.joinpath(*normalized.parts)
+        if (
+            not path.is_file()
+            or path.suffix.lower() not in _UNITY_SOURCE_SUFFIXES
+        ):
+            continue
+        # A generated test may mention UI types while asserting that UI is
+        # absent; only inspect implementation files here.
+        if any("test" in part.lower() for part in normalized.parts):
+            continue
+        if {
+            part.lower() for part in normalized.parts[:-1]
+        } & _UNITY_UI_PATH_PARTS:
+            violations.append(
+                "Unity Mechanic source is under a UI-owned path in "
+                f"{relative_path}"
+            )
+        try:
+            source = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError as exc:
+            violations.append(
+                "Unable to inspect generated Unity Mechanic source "
+                f"{relative_path}: {exc}"
+            )
+            continue
+        matches = [
+            name
+            for name, pattern in _UNITY_UI_PATTERNS
+            if pattern.search(source)
+        ]
+        if matches:
+            violations.append(
+                "Unity Mechanic source contains forbidden UI "
+                f"implementation in {relative_path}: "
+                + ", ".join(matches)
+            )
+    return not violations, violations
 
 
 def scan_ue_ui_contamination(
@@ -314,6 +388,15 @@ def required_artifact_checks(
         errors.extend(contamination_errors)
     else:
         checks["godot_ui_free_source"] = None
+    if engine.strip().lower() in _UNITY_ENGINE_IDS:
+        ui_free, contamination_errors = scan_unity_ui_contamination(
+            workspace,
+            current_task_files,
+        )
+        checks["unity_ui_free_source"] = ui_free
+        errors.extend(contamination_errors)
+    else:
+        checks["unity_ui_free_source"] = None
     return checks, errors, warnings
 
 

--- a/pipeline/code_gen/gen_mechanic/artifacts.py
+++ b/pipeline/code_gen/gen_mechanic/artifacts.py
@@ -55,6 +55,36 @@ _UE_UI_PATTERNS = (
     ("UMG", re.compile(r"\bUMG\b")),
     ("Slate", re.compile(r"\bSlate(?:Core)?\b")),
 )
+_GODOT_ENGINE_IDS = {
+    "godot",
+    "godot4",
+    "godot_engine",
+}
+_GODOT_SOURCE_SUFFIXES = {
+    ".gd",
+    ".tscn",
+    ".tres",
+}
+_GODOT_UI_PATTERNS = (
+    ("CanvasLayer", re.compile(r"\bCanvasLayer\b")),
+    ("Control", re.compile(r"\bControl\b")),
+    ("Container", re.compile(r"\b[A-Za-z]*Container\b")),
+    ("Label", re.compile(r"\bLabel\b")),
+    ("Button", re.compile(r"\b(?:BaseButton|Button|TextureButton)\b")),
+    ("Panel", re.compile(r"\b(?:Panel|PanelContainer)\b")),
+    ("ProgressBar", re.compile(r"\bProgressBar\b")),
+    ("ColorRect", re.compile(r"\bColorRect\b")),
+    ("TextureRect", re.compile(r"\bTextureRect\b")),
+    ("CombatUI", re.compile(r"\bCombatUI\b|combat_ui\.gd")),
+    ("res://ui/", re.compile(r"res://ui[\\/]")),
+)
+_GODOT_UI_PATH_PARTS = {
+    "ui",
+    "hud",
+    "widget",
+    "widgets",
+    "overlay",
+}
 
 
 def _has_files(path: Path) -> bool:
@@ -95,6 +125,53 @@ def scan_ue_ui_contamination(
         if matches:
             violations.append(
                 "UE Mechanic source contains forbidden UI "
+                f"implementation in {relative_path}: "
+                + ", ".join(matches)
+            )
+    return not violations, violations
+
+
+def scan_godot_ui_contamination(
+    workspace: Path,
+    current_task_files: Mapping[str, Mapping[str, Any]],
+) -> tuple[bool, list[str]]:
+    """Reject native UI implementation accidentally put in a Godot Mechanic."""
+    violations: list[str] = []
+    for relative_path in current_task_files:
+        normalized = PurePosixPath(str(relative_path).replace("\\", "/"))
+        path = workspace.joinpath(*normalized.parts)
+        if (
+            not path.is_file()
+            or path.suffix.lower() not in _GODOT_SOURCE_SUFFIXES
+        ):
+            continue
+        # A generated test may mention UI types while asserting that UI is
+        # absent; only inspect implementation files here.
+        if any("test" in part.lower() for part in normalized.parts):
+            continue
+        if {
+            part.lower() for part in normalized.parts[:-1]
+        } & _GODOT_UI_PATH_PARTS:
+            violations.append(
+                "Godot Mechanic source is under a UI-owned path in "
+                f"{relative_path}"
+            )
+        try:
+            source = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError as exc:
+            violations.append(
+                "Unable to inspect generated Godot Mechanic source "
+                f"{relative_path}: {exc}"
+            )
+            continue
+        matches = [
+            name
+            for name, pattern in _GODOT_UI_PATTERNS
+            if pattern.search(source)
+        ]
+        if matches:
+            violations.append(
+                "Godot Mechanic source contains forbidden UI "
                 f"implementation in {relative_path}: "
                 + ", ".join(matches)
             )
@@ -228,6 +305,15 @@ def required_artifact_checks(
         errors.extend(contamination_errors)
     else:
         checks["ue_ui_free_source"] = None
+    if engine.strip().lower() in _GODOT_ENGINE_IDS:
+        ui_free, contamination_errors = scan_godot_ui_contamination(
+            workspace,
+            current_task_files,
+        )
+        checks["godot_ui_free_source"] = ui_free
+        errors.extend(contamination_errors)
+    else:
+        checks["godot_ui_free_source"] = None
     return checks, errors, warnings
 
 

--- a/pipeline/code_gen/gen_mechanic/eval.py
+++ b/pipeline/code_gen/gen_mechanic/eval.py
@@ -160,6 +160,10 @@ def evaluate_artifact(
             ui_free_source = artifact_checks.get(
                 "godot_ui_free_source"
             )
+        if ui_free_source is None:
+            ui_free_source = artifact_checks.get(
+                "unity_ui_free_source"
+            )
         checks["ui_free_source"] = (
             ui_free_source is True
             or ui_free_source is None

--- a/pipeline/code_gen/gen_mechanic/eval.py
+++ b/pipeline/code_gen/gen_mechanic/eval.py
@@ -155,9 +155,11 @@ def evaluate_artifact(
             artifact_checks.get("context_used")
             is True
         )
-        ui_free_source = artifact_checks.get(
-            "ue_ui_free_source"
-        )
+        ui_free_source = artifact_checks.get("ue_ui_free_source")
+        if ui_free_source is None:
+            ui_free_source = artifact_checks.get(
+                "godot_ui_free_source"
+            )
         checks["ui_free_source"] = (
             ui_free_source is True
             or ui_free_source is None

--- a/pipeline/code_gen/gen_mechanic/run.py
+++ b/pipeline/code_gen/gen_mechanic/run.py
@@ -18,6 +18,7 @@ from pipeline.code_gen.gen_mechanic.artifacts import (
     required_artifact_checks as _required_artifact_checks,
     scan_godot_ui_contamination as _scan_godot_ui_contamination,
     scan_ue_ui_contamination as _scan_ue_ui_contamination,
+    scan_unity_ui_contamination as _scan_unity_ui_contamination,
 )
 from pipeline.code_gen.gen_mechanic.contracts import (
     MECHANIC_CONTRACT_FILENAME,

--- a/pipeline/code_gen/gen_mechanic/run.py
+++ b/pipeline/code_gen/gen_mechanic/run.py
@@ -16,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
 from pipeline.code_gen.gen_mechanic.artifacts import (
     finalize,
     required_artifact_checks as _required_artifact_checks,
+    scan_godot_ui_contamination as _scan_godot_ui_contamination,
     scan_ue_ui_contamination as _scan_ue_ui_contamination,
 )
 from pipeline.code_gen.gen_mechanic.contracts import (


### PR DESCRIPTION
Add scan_godot_ui_contamination to gen_mechanic/artifacts.py to check mechanic source files for forbidden UI implementation, matching the existing UE scanner. Wire it into run.py imports and eval.py check logic. Fix godot_example.py browser serving backend.